### PR TITLE
Add missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ requirements = [
     'urllib3[secure]',
     'pysocks',
     'gevent',
-    'stem'
+    'stem',
+    'certifi'
 ]
 
 setup_requirements = [


### PR DESCRIPTION
lyricsmaster relies on certifi, which is not yet pulled in from within `setup.py`.